### PR TITLE
Added change of variable term to tau decay

### DIFF
--- a/private/LeptonWeighter/Weighter.cpp
+++ b/private/LeptonWeighter/Weighter.cpp
@@ -79,7 +79,8 @@ double Weighter::get_effective_tau_oneweight(Event & e) const{
                                                                       e_tau.energy, e_tau.interaction_x, y_tau);
                       double dndz = tds.TauDecayToLepton(Etau,Emu)*tds.GetTauToLeptonBranchingRatio();
                       if(dxs*dndz <0) return 0.0;
-                      return dxs*dndz;
+                      double dzdy = e_tau.energy/Etau;
+                      return dxs*dndz*dzdy;
                     },
                     y_min, y_max, int_precision, &intOpt);
     if(intOpt.outOfTolerance){


### PR DESCRIPTION
The double differential cross section should be d^2 sigma/ dx dy. Therefore, a change of variable should be done on dn/dz so that the random variable is y. This adds the term dz/dy, which is equivalent to E_numu/E_tau = E_nutau / E_tau. 